### PR TITLE
Support Landscape

### DIFF
--- a/EZLoadingActivity.swift
+++ b/EZLoadingActivity.swift
@@ -103,7 +103,9 @@ public struct EZLoadingActivity {
         convenience init(text: String, disableUI: Bool) {
             let width = UIScreen.ScreenWidth / Settings.WidthDivision
             let height = width / 3
-            self.init(frame: CGRect(x: UIScreen.ScreenWidth/2 - width/2, y: UIScreen.ScreenHeight/2 - height/2, width: width, height: height))
+            self.init(frame: CGRect(x: 0, y: 0, width: width, height: height))
+            center = CGPoint(x: UIScreen.mainScreen().bounds.midX, y: UIScreen.mainScreen().bounds.midY)
+            autoresizingMask = [.FlexibleTopMargin, .FlexibleLeftMargin, .FlexibleBottomMargin, .FlexibleRightMargin]
             backgroundColor = Settings.BackgroundColor
             alpha = 1
             layer.cornerRadius = 8

--- a/EZLoadingActivity/ViewController.swift
+++ b/EZLoadingActivity/ViewController.swift
@@ -10,22 +10,30 @@ import UIKit
 
 class ViewController: UIViewController {
 
+    private lazy var button: UIButton = {
+        let _button = UIButton(type: .System)
+        _button.setTitle("Show EZLoadingActivity", forState: .Normal)
+        _button.addTarget(self, action: Selector("showLoadingActivity:"), forControlEvents: .TouchUpInside)
+        return _button
+    }()
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view, typically from a nib.
-        
+        view.addSubview(button)
+
+        if #available(iOS 9.0, *) {
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.centerXAnchor.constraintEqualToAnchor(view.centerXAnchor).active = true
+            button.centerYAnchor.constraintEqualToAnchor(view.centerYAnchor).active = true
+        } else {
+            button.sizeToFit()
+            button.center = CGPoint(x: view.bounds.midX, y: view.bounds.midY)
+            button.autoresizingMask = [.FlexibleTopMargin, .FlexibleLeftMargin, .FlexibleBottomMargin, .FlexibleRightMargin]
+        }
     }
 
-    override func viewDidAppear(animated: Bool) {
-        super.viewDidAppear(animated)
+    @IBAction func showLoadingActivity(sender: UIButton) {
         EZLoadingActivity.showWithDelay("Testing..", disableUI: false, seconds: 3)
-
     }
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
-    }
-
 
 }
-


### PR DESCRIPTION
It should work with device rotation when the loading activity shows on screen.
