### PR TITLE
Separate instantiation from showing the view. Otherwise it can happen…

### DIFF
--- a/EZLoadingActivity.podspec
+++ b/EZLoadingActivity.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 s.name             = "EZLoadingActivity"
-s.version          = "0.7"
+s.version          = "0.8"
 s.summary          = "Lightweight Swift loading activity for iOS7+"
 s.description      = "Lightweight Swift loading activity for iOS7+. Really simple to use, just add the class and write 1 line of code."
 s.homepage         = "https://github.com/goktugyil/EZLoadingActivity"

--- a/EZLoadingActivity.swift
+++ b/EZLoadingActivity.swift
@@ -50,9 +50,10 @@ public struct EZLoadingActivity {
             print("EZLoadingActivity Error: You don't have any views set. You may be calling them in viewDidLoad. Try viewDidAppear instead.")
             return false
         }
-        
+        // Separate creation from showing
+        instance = LoadingActivity(text: text, disableUI: disableUI)
         dispatch_async(dispatch_get_main_queue()) {
-            instance = LoadingActivity(text: text, disableUI: disableUI)
+            instance?.showLoadingActivity()
         }
         return true
     }
@@ -126,15 +127,17 @@ public struct EZLoadingActivity {
             textLabel.textAlignment = NSTextAlignment.Center
             textLabel.text = text
             
-            addSubview(activityView)
-            addSubview(textLabel)
-            
-            topMostController!.view.addSubview(self)
-            
             if disableUI {
                 UIApplication.sharedApplication().beginIgnoringInteractionEvents()
                 UIDisabled = true
             }
+        }
+        
+        func showLoadingActivity() {
+            addSubview(activityView)
+            addSubview(textLabel)
+            
+            topMostController!.view.addSubview(self)
         }
         
         func createShadow() {


### PR DESCRIPTION
… that you end up in a situation where the UI is blocked.

In the original version where instantiation and showing is done in one step (dispatch main) it can be that the dispatch didn't occur when you call the hide method. Hide is checking as a first step if there is an instance, which is not, because the main thread didn't elaborate it yet, and exits.
Then at a point in time the main thread is showing the Indicator with blocking id, and never gets dismissed.

With this change the instance is there, even if it hasn't been shown and as both showing and hiding happen in the same thread (main) it will be shown and immediately hidden, and the UI is unblocked.
