### PR TITLE
Fixed deprecation of swift v3 selectors

### DIFF
--- a/EZLoadingActivity.swift
+++ b/EZLoadingActivity.swift
@@ -222,13 +222,13 @@ public struct EZLoadingActivity {
                 UIView.animateWithDuration(animationDuration, animations: {
                     self.icon.alpha = 1
                     }, completion: { (value: Bool) in
-                        self.callSelectorAsync("removeFromSuperview", delay: animationDuration)
+                        self.callSelectorAsync(#selector(UIView.removeFromSuperview), delay: animationDuration)
                         instance = nil
                         hidingInProgress = false
                 })
             } else {
                 activityView.stopAnimating()
-                self.callSelectorAsync("removeFromSuperview", delay: animationDuration)
+                self.callSelectorAsync(#selector(UIView.removeFromSuperview), delay: animationDuration)
                 instance = nil
                 hidingInProgress = false
             }


### PR DESCRIPTION
Added new API reference according to specification.
https://github.com/apple/swift-evolution/blob/master/proposals/0022-objc-selectors.md
